### PR TITLE
AUTOSCALE-193: Add entrypoint to aws provider containerfile to match upstream behavior

### DIFF
--- a/openshift/Containerfile.rhel
+++ b/openshift/Containerfile.rhel
@@ -8,3 +8,5 @@ ARG TARGETARCH
 COPY --from=builder /go/src/github.com/openshift/aws-karpenter-provider-aws/karpenter-provider-aws-${TARGETARCH} /usr/bin/karpenter-provider-aws
 LABEL io.k8s.display-name="Karpenter AWS provider for OpenShift" \
       io.k8s.description="Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity."
+# the upstream image has an entrypoint set, this entrypoint is for parity so the args to the pod can be the same and they are interchangeable
+ENTRYPOINT ["/usr/bin/karpenter-provider-aws"]


### PR DESCRIPTION
Upstream has an entrypoint specified in their containerfile, hypershift was hard coded to use an upstream image, but we need to use our shipping one now, and we'd prefer not to have to change the args based on which one we're using.

This just adds the entrypoint so the upstream/downstream image usages are interchangeable (at least until we skew on args or something with carry patches someday).

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Upstream images have an entrypoint, our containerfile didn't. We're going to swap this image in for the one in hypershift and it would be nice if they were interchangeable and we didn't have to horse with the args/remember a special case for downstream. 

**How was this change tested?**

```
podman build -f openshift/Containerfile.rhel  -t testme
podman run -it --rm testme 
```


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.