### PR TITLE
AUTOSCALE-193: temporarily apply operator label for inclusion in release

### DIFF
--- a/openshift/Containerfile.rhel
+++ b/openshift/Containerfile.rhel
@@ -8,5 +8,9 @@ ARG TARGETARCH
 COPY --from=builder /go/src/github.com/openshift/aws-karpenter-provider-aws/karpenter-provider-aws-${TARGETARCH} /usr/bin/karpenter-provider-aws
 LABEL io.k8s.display-name="Karpenter AWS provider for OpenShift" \
       io.k8s.description="Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity."
+# TODO(jkyros): The right way to do this is eventually to put it in the hypershift image references, but if 
+# we do that before it's in the payload, it will break hypershift builds. Once it's in hypershift's image-references
+# we should take the label off so we get included because hypershift asks for us, not because we said we were important
+LABEL io.openshift.release.operator=true
 # the upstream image has an entrypoint set, this entrypoint is for parity so the args to the pod can be the same and they are interchangeable
 ENTRYPOINT ["/usr/bin/karpenter-provider-aws"]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Now that we have https://github.com/openshift/release/pull/63681, this should make the hypershift test use our image vs the upstream one. 

In order to be included in the payload we have to either: 
- label ourselves as an operator or
- have hypershift include us in their image references
otherwise `oc adm release new` will discard our image as unused when it builds the payload. 

Eventually we want to have hypershift reference us but we can't do that yet because we're not in the payload yet, so for now this is "label ourselves as an operator so we get included" so we can test, etc and then once we're in the payload we can PR to hypershift to have them reference us and take this out. 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.