### PR TITLE
AUTOSCALE-259: migrate upstream karpenter-core dependency to downstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,3 +121,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 )
+
+// Use our openshift version of kubernetes-sigs/karpenter instead of upstream
+replace sigs.k8s.io/karpenter => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20250611163250-9ec6578ef19c

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU
 github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
+github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20250611163250-9ec6578ef19c h1:yKmsMndFqkpsgJvURg7y4b3OlLdm1/RsWktS6cbvkH0=
+github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20250611163250-9ec6578ef19c/go.mod h1:CTQOmDpbYMTY6uvRZ6XoyKNXWoIMVbCOGCkgvYeZSO4=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
@@ -345,8 +347,6 @@ sigs.k8s.io/controller-runtime v0.20.1 h1:JbGMAG/X94NeM3xvjenVUaBjy6Ui4Ogd/J5Ztj
 sigs.k8s.io/controller-runtime v0.20.1/go.mod h1:BrP3w158MwvB3ZbNpaAcIKkHQ7YGpYnzpoSTZ8E14WU=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
-sigs.k8s.io/karpenter v1.2.2 h1:aiks+/3JHIMtEw+gQXdw7cf2M/ZTcpto4BOHE9dC40U=
-sigs.k8s.io/karpenter v1.2.2/go.mod h1:CTQOmDpbYMTY6uvRZ6XoyKNXWoIMVbCOGCkgvYeZSO4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1026,7 +1026,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 ## explicit; go 1.21
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/karpenter v1.2.2
+# sigs.k8s.io/karpenter v1.2.2 => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20250611163250-9ec6578ef19c
 ## explicit; go 1.23.6
 sigs.k8s.io/karpenter/pkg/apis
 sigs.k8s.io/karpenter/pkg/apis/v1
@@ -1094,3 +1094,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# sigs.k8s.io/karpenter => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20250611163250-9ec6578ef19c


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
Adds a replace directive to replace the upstream dependency to our downstream fork at https://github.com/openshift/kubernetes-sigs-karpenter.

Steps I did:
```bash
go mod edit -replace=sigs.k8s.io/karpenter=github.com/openshift/kubernetes-sigs-karpenter@latest
go mod tidy && go mod vendor && go mod verify
# then added a comment manually to go.mod
```

Since our karpenter-core downstream is functionallty equivanent to the previous upstream version we were using, go mod vendor did not add any changes reflected in the modified files in this PR.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.