### PR TITLE
AUTOSCALE-401: Post rebase cleanup - move kubernetes-sigs-karpenter back to main, re-add payload image label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,4 +128,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
-replace sigs.k8s.io/karpenter => github.com/jkyros/kubernetes-sigs-karpenter v0.0.0-20251104033130-4640c3a83366
+replace sigs.k8s.io/karpenter => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20251113050548-80a590d42358

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jkyros/kubernetes-sigs-karpenter v0.0.0-20251104033130-4640c3a83366 h1:Pgur7buGzgxPl60PAbthhfX6eKwit/AYhpNepEUpDfQ=
-github.com/jkyros/kubernetes-sigs-karpenter v0.0.0-20251104033130-4640c3a83366/go.mod h1:nDDVB5873dVVuyTam3oJrllSv0sAgp6as6/5HRTcV4o=
 github.com/jonathan-innis/aws-sdk-go-prometheus v0.1.1 h1:gmpuckrozJ3lfKqSIia9YMGh0caoQmEY7mQP5MsnbTM=
 github.com/jonathan-innis/aws-sdk-go-prometheus v0.1.1/go.mod h1:168XvZFghCqo32ISSWnTXwdlMKzEq+x9TqdfswCjkrQ=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -170,6 +168,8 @@ github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw
 github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20251113050548-80a590d42358 h1:9LHP1Lu1nwfScPgonHicitmafqhUf2G7kWpL+Mw4NzY=
+github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20251113050548-80a590d42358/go.mod h1:nDDVB5873dVVuyTam3oJrllSv0sAgp6as6/5HRTcV4o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/openshift/Containerfile.rhel
+++ b/openshift/Containerfile.rhel
@@ -8,5 +8,9 @@ ARG TARGETARCH
 COPY --from=builder /go/src/github.com/openshift/aws-karpenter-provider-aws/karpenter-provider-aws-${TARGETARCH} /usr/bin/karpenter-provider-aws
 LABEL io.k8s.display-name="Karpenter AWS provider for OpenShift" \
       io.k8s.description="Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity."
+# TODO(jkyros): The right way to do this is eventually to put it in the hypershift image references, but if 
+# we do that before it's in the payload, it will break hypershift builds. Once it's in hypershift's image-references
+# we should take the label off so we get included because hypershift asks for us, not because we said we were important
+LABEL io.openshift.release.operator=true
 # the upstream image has an entrypoint set, this entrypoint is for parity so the args to the pod can be the same and they are interchangeable
 ENTRYPOINT ["/usr/bin/karpenter-provider-aws"]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1071,7 +1071,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 ## explicit; go 1.23
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/karpenter v1.8.0 => github.com/jkyros/kubernetes-sigs-karpenter v0.0.0-20251104033130-4640c3a83366
+# sigs.k8s.io/karpenter v1.8.0 => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20251113050548-80a590d42358
 ## explicit; go 1.24.6
 sigs.k8s.io/karpenter/kwok/apis
 sigs.k8s.io/karpenter/kwok/apis/v1alpha1
@@ -1153,4 +1153,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# sigs.k8s.io/karpenter => github.com/jkyros/kubernetes-sigs-karpenter v0.0.0-20251104033130-4640c3a83366
+# sigs.k8s.io/karpenter => github.com/openshift/kubernetes-sigs-karpenter v0.0.0-20251113050548-80a590d42358


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Now that we have: 
- https://github.com/openshift/kubernetes-sigs-karpenter/pull/11
- https://github.com/openshift/aws-karpenter-provider-aws/pull/16

And they've been merged and tested together, we can move our replace directive back to point at `kubernetes-sigs-karpenter/main` until the next chore cycle.  Yes, we do desire to make this less convoluted in the future :smile:

Note: 
- I totally goofed one of my squashes and dropped the payload inclusion label, so this puts it back in, too. I checked hypershift and it's not in there yet, so we probably still need to do that over there at some point so they require our image instead of us force-injecting it. 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.